### PR TITLE
Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # plex-imdb-ratings
 Python scripts for downloading your IMDb user ratings and importing them into Plex.
 ## Installation and Setup
-Clone or download this project to a location on your computer.
+Clone or download this project to a location on your computer. You can install the required packages either with pip...
+```commandline
+pip install -r requirements.txt
+```
+...or by creating a conda environment.
+```commandline
+conda env create -f environment.yml
+```
 
-Microsoft Edge must be installed. This project downloads your IMDb ratings using a Selenium Edge web driver.
+After installing playwright, you must run `playwright install` to install the required browsers.
 
-Make sure you are logged in to IMDb.com on Edge under the profile specified in your configuration file. IMDb has measures that prevent the use of automated methods to login, so we must load a user profile that is already logged in to the site.
+A Chromium-based web browser (Google Chrome or Microsoft Edge) must be installed on your computer. Make sure you are logged in to IMDb.com on Chrome or Edge under the profile specified in your configuration file. IMDb has measures that prevent the use of automated methods to login, so we must load a user profile that is already logged in to the site.
 ## Usage
 ```
 python download_ratings.py <config_file>

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ dependencies:
     - pip=23.2
     - python=3.10
     - pip:
-        - fake-useragent==1.1.3
         - plexapi==4.14.0
         - pyyaml==6.0.1
-        - selenium==4.10.0
+        - playwright==1.37.0

--- a/import_ratings.py
+++ b/import_ratings.py
@@ -1,6 +1,7 @@
 import argparse
 import csv
 import datetime
+import os
 
 import plexapi.exceptions
 from plexapi.server import PlexServer
@@ -33,8 +34,9 @@ def rate(imdb_id, rating):
 
 
 def log_date():
+    ratings_date = datetime.datetime.fromtimestamp(os.path.getmtime('ratings.csv')).date()
     f = open(log_file, 'w')
-    f.write(str(datetime.datetime.now().date()))
+    f.write(str(ratings_date))
     f.close()
 
 

--- a/import_ratings.py
+++ b/import_ratings.py
@@ -52,6 +52,9 @@ def import_ratings():
     last_run_dt = last_run()
     last_run_dt = datetime.datetime.strptime(last_run_dt, '%Y-%m-%d')
 
+    recently_added = plex_lib.search(filters={"addedAt>>=": last_run_dt})
+    recently_added = [g.id[g.id.find('://') + 3:] for x in recently_added for g in x.guids if g.id[:4] == 'imdb']
+
     with open(ratings_file, "r") as csv_file:
         reader = csv.reader(csv_file)
         next(reader)  # Skip the first row (the header row)
@@ -63,7 +66,7 @@ def import_ratings():
             rating = int(row[1])
             imdb_id = row[0]
 
-            if date_rated >= last_run_dt:
+            if (date_rated >= last_run_dt) or (imdb_id in recently_added):
                 # Select movie in Plex library by IMDb id
                 try:
                     rate(imdb_id, rating)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-fake-useragent~=1.1.3
 plexapi~=4.14.0
 pyyaml~=6.0.1
-selenium~=4.10.0
+playwright~=1.37.0


### PR DESCRIPTION
The original Selenium implementation was unreliable. This rewrites the `download_ratings.py` script to use Playwright instead. 

Additional bugs were fixed:

- Movies that were already rated on IMDb before being added to Plex could be missed and not rated.
- If something caused the `download_ratings` script to fail but `import_ratings` completed successfully, the last run date was still updated. This means any movies that had been rated since the previous run date would be missed the next time `download_ratings` successfully ran.