### PR TITLE
Upgrade to playwright 1.40.0

### DIFF
--- a/download_ratings.py
+++ b/download_ratings.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 
 from playwright.sync_api import sync_playwright
-from playwright._impl._api_types import Error as PlaywrightAPIError
+from playwright._impl._errors import Error as PlaywrightAPIError
 
 from read_config import read_config
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,4 @@ dependencies:
     - pip:
         - plexapi==4.14.0
         - pyyaml==6.0.1
-        - playwright==1.37.0
+        - playwright==1.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 plexapi~=4.14.0
 pyyaml~=6.0.1
-playwright~=1.37.0
+playwright~=1.40.0


### PR DESCRIPTION
download_ratings.py was failing. Playwright didn't seem to be opening a browser with a user data directory, despite one being specified, so user was not signed in to IMDb.com. This PR upgrades Playwright to the latest version in an attempt to fix this.